### PR TITLE
Se añaden test para integración continua

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: BillReader test
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [ main, development ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, development ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/testLinux.yml
+++ b/.github/workflows/testLinux.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: BillReader test
+name: BillReader Linux Test
 
 # Controls when the action will run. 
 on:

--- a/.github/workflows/testMacOS.yml
+++ b/.github/workflows/testMacOS.yml
@@ -1,0 +1,35 @@
+# This is a basic workflow to help you get started with Actions
+
+name: BillReader MacOS Test
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main, development ]
+  pull_request:
+    branches: [ main, development ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+        
+      - name: Test
+        run: dotnet test --no-restore

--- a/.github/workflows/testWindows.yml
+++ b/.github/workflows/testWindows.yml
@@ -1,0 +1,35 @@
+# This is a basic workflow to help you get started with Actions
+
+name: BillReader Windows Test
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main, development ]
+  pull_request:
+    branches: [ main, development ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+        
+      - name: Test
+        run: dotnet test --no-restore

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ BillReader/obj
 BillReaderTest/bin
 BillReaderTest/obj
 BillReaderTest/TestResults
+BillReader/BillReader.csproj.user


### PR DESCRIPTION
Se añaden nuevos tests de integración continua para máquinas de windows y MacOS.
Se fuerza a ejecutar la acción también en la rama development.